### PR TITLE
Fix loop device failure handling

### DIFF
--- a/src/docker/build_image.sh
+++ b/src/docker/build_image.sh
@@ -97,7 +97,8 @@ truncate -s "$IMG_SIZE" "$IMG_PATH"
 # - --show: Print the assigned device name
 # - --partscan: Scan for partitions after setup
 if ! LOOPDEV=$(losetup --find --show --partscan "$IMG_PATH"); then
-  echo "[warn] No free loop devices; opening shell for inspection."
+  echo "[error] Failed to allocate loop device" >&2
+  exit 1
 fi
 
 # Ensure loop device is detached on script exit


### PR DESCRIPTION
## Summary
- fail fast if no loop device is available during image build

## Testing
- `shellcheck src/docker/build_image.sh`
- `hooks/find_shell_scripts.sh | xargs shellcheck`

------
https://chatgpt.com/codex/tasks/task_e_687dda6ef4d883278470249a0c6f2c9c